### PR TITLE
Changes to page footer

### DIFF
--- a/src/components/footer/CopyrightBar.js
+++ b/src/components/footer/CopyrightBar.js
@@ -1,7 +1,7 @@
 function CopyrightBar(props) {
     return(
         <div>
-            <h3>Copyright 2021 Nithin Pradeep</h3>
+            <h6 className="Footer-Copyright">Copyright 2021 Nithin Pradeep</h6>
         </div>
     )
 }

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -1,33 +1,51 @@
-import { CardGroup } from "react-bootstrap";
+import { Card, CardGroup, Col, Container, Row } from "react-bootstrap";
 import CopyrightBar from "./CopyrightBar";
+import FooterContact from "./FooterContact";
+import FooterLast from "./FooterLast";
+import FooterLink from "./FooterLinks";
 import References from "./References";
 
 function Footer(props) {
-    var media = socialMedia
     return(
-        <div>
-            <CardGroup>
-            {media.map((item) => 
-                <References key={item.title} title={item.title} url={item.url} image={item.img} />
-            )}
-            </CardGroup>
-            {/* <References /> */}
-            <CopyrightBar />
-        </div>
+        // <div>
+        //     <CardGroup>
+        //     <Card style={{ width: '18rem' }}>
+        //     <Card.Body>
+        //         <Card.Title>Card Title</Card.Title>
+        //         <Card.Subtitle className="mb-2 text-muted">Card Subtitle</Card.Subtitle>
+        //         <Card.Text>
+        //         Some quick example text to build on the card title and make up the bulk of
+        //         the card's content.
+        //         </Card.Text>
+        //         <Card.Link href="#">Card Link</Card.Link>
+        //         <Card.Link href="#">Another Link</Card.Link>
+        //     </Card.Body>
+        //     </Card>
+        //     {media.map((item) => 
+        //         <References key={item.title} title={item.title} url={item.url} image={item.img} />
+        //     )}
+        //     </CardGroup>
+        //     {/* <References /> */}
+        //     <CopyrightBar />
+        // </div>
+		<Container>
+			<Row xs={1} md={3} lg={3}>
+				<Col>
+                    <FooterLink 
+                        instaLink="https://www.instagram.com" 
+                        twitterLink="https://twitter.com" 
+                        youtubeLink="https://www.youtube.com" 
+                        linkedInLink="https://www.linkedin.com" 
+                    />
+                </Col>
+				<Col><FooterContact /></Col>
+				<Col><FooterLast discordUrl="https://www.google.com"/></Col>
+			</Row>
+            <Row xs={1} md={1} lg={1}>
+                <CopyrightBar />
+            </Row>
+		</Container>
     )
 }
-
-const socialMedia = [
-    {
-        title: "Instagram",
-        url: "https://www.instagram.com/privatefeed_nofollow/",
-        img: "./instagram-text.svg"
-    },
-    {
-        title: "LinkedIn",
-        url: "https://www.linkedin.com/in/nithin-pradeep-80822414b/",
-        img: "https://upload.wikimedia.org/wikipedia/commons/0/01/LinkedIn_Logo.svg"
-    }
-]
 
 export default Footer

--- a/src/components/footer/FooterContact.js
+++ b/src/components/footer/FooterContact.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { Container, Row } from "react-bootstrap";
+
+export default class FooterContact extends React.Component {
+    render() {
+        return(
+            <Container>
+                <Row><br /></Row>
+                <Row className="Footer-Title2">Support</Row>
+                <Row><br/></Row>
+                <Row>Contact Us</Row>
+                <Row>FAQ</Row>
+                <Row>Source Code</Row>
+                <Row>Features</Row>
+            </Container>
+        )
+    }
+}

--- a/src/components/footer/FooterLast.js
+++ b/src/components/footer/FooterLast.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { Button, Col, Container, Form, Row } from "react-bootstrap";
+import MailIcon from "../../resources/MailIconFooter.svg"
+import DiscordIdle from "../../resources/DiscordIdle.svg"
+import DiscordPlus from "../../resources/DiscordPlus.svg"
+
+export default class FooterLast extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            discordIcon: DiscordIdle
+        }
+    }
+
+    render() {
+        return(
+            <Container>
+                <Row><br /></Row>
+                <Form.Group as={Row} className="mb-3" controlId="formPlaintextEmail">
+                    <Form.Label column sm="2">
+                    <img src={MailIcon} width={30} />
+                    </Form.Label>
+                    <Col sm="10">
+                    <Form.Control plaintext readOnly defaultValue="Subscribe to our newsletter" />
+                    </Col>
+                </Form.Group>
+                <Form>
+                    <Form.Group className="mb-3" controlId="formBasicEmail">
+                        <Form.Control type="email" placeholder="Enter email" />
+                    </Form.Group>
+                    <Button variant="primary" type="submit">
+                        Submit
+                    </Button>
+                </Form>
+                <Row><br /></Row>
+                <Form.Group as={Row} className="mb-3" controlId="formPlaintextEmail">
+                    <Form.Label column sm="2">
+                    <a href={this.props.discordUrl}><img src={this.state.discordIcon} width={30} /></a>
+                    </Form.Label>
+                    <Col sm="10">
+                    <Form.Control plaintext readOnly defaultValue="Join us on Discord" />
+                    </Col>
+                </Form.Group>
+            </Container>
+        )
+    }
+
+    changeIcon = (icon) => {
+        this.setState({
+            discordIcon: icon
+        })
+    }
+}

--- a/src/components/footer/FooterLinks.js
+++ b/src/components/footer/FooterLinks.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { Col, Container, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
+import InstagramIcon from "../../resources/InstagramFooterIcon.svg"
+import LinkedInIcon from "../../resources/LinkedInFooterIcon.svg"
+import TwitterIcon from "../../resources/TwitterFooterIcon.svg"
+import YoutubeIcon from "../../resources/YoutubeFooterIcon.svg"
+
+export default class FooterLinks extends React.Component {
+    render() {
+        return(
+            <div>
+                <Container>
+                    <Row>
+                        <Container className="Footer-Title">Portfolio</Container>
+                    </Row>
+                    <Row><br/></Row>
+                    <Row>
+                        <Col><a href={this.props.instaLink}><img src={InstagramIcon} width={40} /></a></Col>
+                        <Col><a href={this.props.twitterLink}><img src={TwitterIcon} width={40} /></a></Col>
+                        <Col><a href={this.props.youtubeLink}><img src={YoutubeIcon} width={40} /></a></Col>
+                        <Col><a href={this.props.linkedInLink}><img src={LinkedInIcon} width={40} /></a></Col>
+                    </Row>
+                </Container>
+            </div>
+        )
+    }
+
+    clickedIcon() {
+        console.log("Hello")
+    }
+}


### PR DESCRIPTION
This merge request contains a complete cleanup of the footer of webpage. This includes:

- Getting rid of cluttered cards present

- Adding minimalist design via icons and forms

- Proper alignment of all content in page  

PFA below a screenshot of what the page currently looks like. 
 
<img width="1487" alt="Screenshot 2022-03-27 at 4 53 01 PM" src="https://user-images.githubusercontent.com/43707650/160279173-01de437c-14c2-41d9-b702-48f64e162813.png">

Note: The copyright bar and submit button are still work-in-progress. We need to fix the alignment and final content.
 